### PR TITLE
Add network versions of MB2100 class printers

### DIFF
--- a/scangearmp2/src/canon_mfp2.conf
+++ b/scangearmp2/src/canon_mfp2.conf
@@ -36,6 +36,12 @@
 [MB5100 series] 0x1790 0x0137
 [MB5400 series] 0x178F 0x0137
 
+# Network attached versions of the above
+[MB2100 series] 0x1793 0x0173
+[MB2700 series] 0x1792 0x0173
+[MB5100 series] 0x1790 0x0177
+[MB5400 series] 0x178F 0x0177
+
 #---- V330 --------------------------
 [G3000 series] 0x1794 0x0131
 


### PR DESCRIPTION
Thanks very much for this project.  I've just setup up a Canon Maxify MB2120 using it, but the existing CONF file only lists the MB2100 and others in its class as USB and not network. So I've added and tested a 2nd MB2100 entry for network connection as well as untested (since I don't have them, but they all do support the network) copies for others of the same generation.

---- snip ----
Add a second entry to allow network scanning for the MB2100-class MFPs
which have both USB and net connections possible.