### PR TITLE
Fixes size, resolution and source management.

### DIFF
--- a/scangearmp2/src/canon_mfp_io.c
+++ b/scangearmp2/src/canon_mfp_io.c
@@ -608,11 +608,11 @@ CMT_Status CIJSC_open(
 	const char *name )	/* libusb:00X:00Y or MAC address */
 {
 	CANON_Device *dev;
-	return CIJSC_open2(name,dev);
+	return CIJSC_open2(name,dev, NULL);
 }
 
 CMT_Status CIJSC_open2(
-	const char *name,CANON_Device *dev )	/* libusb:00X:00Y or MAC address */
+	const char *name,CANON_Device *dev, CANON_DEVICE_INFO *info )	/* libusb:00X:00Y or MAC address */
 {
 	CMT_Status status;
 	CANON_Scanner *s = &canon_device;
@@ -684,7 +684,7 @@ CMT_Status CIJSC_open2(
 	
 	/* set product id. */
 	DBGMSG("p_canon_init_scanner() product = %X\n", dev->product_id);
-	if ( canon_init_scanner( dev->product_id, dev->speed, NULL ) < 0 ) {
+	if ( canon_init_scanner( dev->product_id, dev->speed, info) < 0 ) {
 		DBGMSG("ERROR : p_canon_init_scanner() product = %d\n", dev->product_id);
 		return (CMT_STATUS_INVAL);
 	}

--- a/scangearmp2/src/canon_mfp_io.c
+++ b/scangearmp2/src/canon_mfp_io.c
@@ -608,11 +608,11 @@ CMT_Status CIJSC_open(
 	const char *name )	/* libusb:00X:00Y or MAC address */
 {
 	CANON_Device *dev;
-	return CIJSC_open2(name,dev, NULL);
+	return CIJSC_open2(name,dev);
 }
 
 CMT_Status CIJSC_open2(
-	const char *name,CANON_Device *dev, CANON_DEVICE_INFO *info )	/* libusb:00X:00Y or MAC address */
+	const char *name,CANON_Device *dev )	/* libusb:00X:00Y or MAC address */
 {
 	CMT_Status status;
 	CANON_Scanner *s = &canon_device;
@@ -684,11 +684,11 @@ CMT_Status CIJSC_open2(
 	
 	/* set product id. */
 	DBGMSG("p_canon_init_scanner() product = %X\n", dev->product_id);
-	if ( canon_init_scanner( dev->product_id, dev->speed, info) < 0 ) {
+	if ( canon_init_scanner( dev->product_id, dev->speed, NULL) < 0 ) {
 		DBGMSG("ERROR : p_canon_init_scanner() product = %d\n", dev->product_id);
 		return (CMT_STATUS_INVAL);
 	}
-	
+
 	opened_handle = dev;
 	memset(&canon_device, 0, sizeof(canon_device));
 	

--- a/scangearmp2/src/canon_mfp_tools.h
+++ b/scangearmp2/src/canon_mfp_tools.h
@@ -156,7 +156,7 @@ CMT_Status CIJSC_init( void *cnnl_callback );
 void CIJSC_exit(void);
 CMT_Status CIJSC_get_devices( const CANON_Device ***device_list );
 CMT_Status CIJSC_open( const char *name );
-CMT_Status CIJSC_open2( const char *name, CANON_Device *dev );
+CMT_Status CIJSC_open2( const char *name, CANON_Device *dev, CANON_DEVICE_INFO *info );
 void CIJSC_close( void );
 
 CMT_Status CIJSC_start( CANON_ScanParam *param );

--- a/scangearmp2/src/canon_mfp_tools.h
+++ b/scangearmp2/src/canon_mfp_tools.h
@@ -156,7 +156,7 @@ CMT_Status CIJSC_init( void *cnnl_callback );
 void CIJSC_exit(void);
 CMT_Status CIJSC_get_devices( const CANON_Device ***device_list );
 CMT_Status CIJSC_open( const char *name );
-CMT_Status CIJSC_open2( const char *name, CANON_Device *dev, CANON_DEVICE_INFO *info );
+CMT_Status CIJSC_open2( const char *name, CANON_Device *dev );
 void CIJSC_close( void );
 
 CMT_Status CIJSC_start( CANON_ScanParam *param );

--- a/scangearmp2/src/sane/canon_pixma.c
+++ b/scangearmp2/src/sane/canon_pixma.c
@@ -1027,7 +1027,7 @@ SCAN_START:
 					/* delete disused file. */
 					DBGMSG("CIJSC_cancel->\n");
 					CIJSC_cancel();
-				return show_sane_cmt_error(CMT_STATUS_CANCELLED);
+				return show_sane_cmt_error(CMT_STATUS_NO_DOCS);
 				}
 			}else {
 				/* delete disused file.*/
@@ -1063,7 +1063,7 @@ sane_get_parameters (SANE_Handle h, SANE_Parameters * p)//voir avec CIJSC_get_pa
 
 	int errCode = 0;
 	ps.depth = 8;//8
-	ps.last_frame = SANE_TRUE;
+	ps.last_frame = (handled->sgmp.scan_scanmode == CIJSC_SCANMODE_PLATEN ? SANE_TRUE : SANE_FALSE);
 	ps.format = SANE_FRAME_RGB;
     	ps.pixels_per_line = handled->sgmp.scan_wx;
     	ps.lines = handled->sgmp.scan_hy;

--- a/scangearmp2/src/sane/canon_pixma.c
+++ b/scangearmp2/src/sane/canon_pixma.c
@@ -89,7 +89,7 @@ _get_source_size(int right, int bottom) {
    int obottom = -1;
    int oright = -1;
    static CIJSC_SIZE_TABLE maw_size = { CIJSC_SIZE_LETTER + 1, 2550, 3507};
-   for (; x < CIJSC_SIZE_NUM; x++) {
+   for (; x < (CIJSC_SIZE_LETTER + 1); x++) {
       if (right > 0) {
          if ( sourceSize[x].right == right)
             return sourceSize[x];

--- a/scangearmp2/src/sane/canon_pixma.h
+++ b/scangearmp2/src/sane/canon_pixma.h
@@ -26,13 +26,13 @@ enum canon_sane_Option
 	OPT_MODE,
 	OPT_RESOLUTION,
 	OPT_PREVIEW,
+	OPT_SCAN_SOURCE,
 
 	OPT_GEOMETRY_GROUP,
 	OPT_TL_X,
 	OPT_TL_Y,
 	OPT_BR_X,
 	OPT_BR_Y,
-	OPT_SCAN_SOURCE,
 	/* must come last: */
 	NUM_OPTIONS
 };

--- a/scangearmp2/src/sane/canon_pixma.h
+++ b/scangearmp2/src/sane/canon_pixma.h
@@ -32,6 +32,7 @@ enum canon_sane_Option
 	OPT_TL_Y,
 	OPT_BR_X,
 	OPT_BR_Y,
+	OPT_SCAN_SOURCE,
 	/* must come last: */
 	NUM_OPTIONS
 };

--- a/scangearmp2/src/sane/errordlg.c
+++ b/scangearmp2/src/sane/errordlg.c
@@ -188,4 +188,3 @@ _EXIT:
 
 
 #endif	/* _ERRORDLG_C_ */
-

--- a/scangearmp2/src/support.h
+++ b/scangearmp2/src/support.h
@@ -186,6 +186,10 @@ typedef struct
 	int			scanning_page;
 	char		file_path[ PATH_MAX ];
 
+	int			scan_x;
+	int			scan_y;
+	int			scan_wx;
+	int			scan_hy;
 	int			scan_w;
 	int			scan_h;
 	int			scan_res;


### PR DESCRIPTION
Fix #24
Support for different resolutions 300 and 600.
Support size in Planten =>   CARD, L_L, L_P, 4X6_L, 4X6_P, HAGAKI_L, HAGAKI_P, 2L_L, 2L_P, A5, B5, A4, LETTER
Support size in ADF =>   A4, LETTER
Support for chaining different sources, flatbed and ADF.
Will be merged after testing.