### PR TITLE
Default paper size

### DIFF
--- a/scangearmp2/src/mainui.c
+++ b/scangearmp2/src/mainui.c
@@ -106,8 +106,10 @@ static int ui_main_is_en_US( void )
 #ifdef USE_PO_LOCALE
 	env_locale = _( "Locale" );
 #else
-	if( ( env_locale = (char *)getenv( "LANG" ) ) == NULL ){
-		env_locale = "";
+	if( ( env_locale = (char *)getenv( "LC_PAPER" ) ) == NULL ){
+		if( ( env_locale = (char *)getenv( "LANG" ) ) == NULL ){
+			env_locale = "";
+		}
 	}
 	env_locale = (char *)strsep( &env_locale, "." );
 #endif


### PR DESCRIPTION
Default paper size (at app start) according to the locale variable LC_PAPER instead of LANG. On systems with system installation language en_US (locale variable LANG) may have another environment configuration for the paper format (locale variable LC_PAPER).