### PR TITLE
Remove unused variables preventing arch linux compile

### DIFF
--- a/src/sane/canon_pixma.c
+++ b/src/sane/canon_pixma.c
@@ -494,6 +494,7 @@ CMT_Status canon_sane_read(canon_sane_t * handled){
 	CMT_Status status = CMT_STATUS_GOOD;
 	unsigned char* buf  = NULL;
 	int readBytes = JPEGSCANBUFSIZE;
+	size_t len = 0;
 	buf = (unsigned char *)calloc(JPEGSCANBUFSIZE,1);
 
 	if(!buf){
@@ -507,9 +508,13 @@ CMT_Status canon_sane_read(canon_sane_t * handled){
 
 	while(status == CMT_STATUS_GOOD && !handled->cancel){
 		/*Read data from the scanner, the data are send in jpeg format*/
+		len = 0;
 		readBytes = JPEGSCANBUFSIZE;
 		status = CIJSC_read(buf,&readBytes);
-		fwrite(buf,1,readBytes,handled->file);
+		len = fwrite(buf,1,readBytes,handled->file);
+		if(len != readBytes){
+			return CMT_STATUS_IO_ERROR;
+		}
 	}
 	if(handled->cancel){
 		status = CMT_STATUS_CANCELLED;

--- a/src/sane/canon_pixma.c
+++ b/src/sane/canon_pixma.c
@@ -494,7 +494,7 @@ CMT_Status canon_sane_read(canon_sane_t * handled){
 	CMT_Status status = CMT_STATUS_GOOD;
 	unsigned char* buf  = NULL;
 	int readBytes = JPEGSCANBUFSIZE;
-	size_t len = 0;
+	int len = 0;
 	buf = (unsigned char *)calloc(JPEGSCANBUFSIZE,1);
 
 	if(!buf){
@@ -513,7 +513,7 @@ CMT_Status canon_sane_read(canon_sane_t * handled){
 		status = CIJSC_read(buf,&readBytes);
 		len = fwrite(buf,1,readBytes,handled->file);
 		if(len != readBytes){
-			return CMT_STATUS_IO_ERROR;
+			status = CMT_STATUS_IO_ERROR;
 		}
 	}
 	if(handled->cancel){

--- a/src/sane/canon_pixma.c
+++ b/src/sane/canon_pixma.c
@@ -494,8 +494,6 @@ CMT_Status canon_sane_read(canon_sane_t * handled){
 	CMT_Status status = CMT_STATUS_GOOD;
 	unsigned char* buf  = NULL;
 	int readBytes = JPEGSCANBUFSIZE;
-	int len = 0;
-	int total =0;
 	buf = (unsigned char *)calloc(JPEGSCANBUFSIZE,1);
 
 	if(!buf){
@@ -509,11 +507,9 @@ CMT_Status canon_sane_read(canon_sane_t * handled){
 
 	while(status == CMT_STATUS_GOOD && !handled->cancel){
 		/*Read data from the scanner, the data are send in jpeg format*/
-		len = 0;
 		readBytes = JPEGSCANBUFSIZE;
 		status = CIJSC_read(buf,&readBytes);
-		len = fwrite(buf,1,readBytes,handled->file);
-		total += len;
+		fwrite(buf,1,readBytes,handled->file);
 	}
 	if(handled->cancel){
 		status = CMT_STATUS_CANCELLED;


### PR DESCRIPTION
I encountered the same issue as https://github.com/ThierryHFR/scangearmp2/issues/73.
I removed the `len` and `total` variables because they are set but not used.